### PR TITLE
Fixing bug that causes the error display to be switched on constantly.

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -91,7 +91,7 @@ limitations under the License.
                                 </StackPanel>
                             </Button.Content>
                         </Button>
-                        <StackPanel Visibility="{Binding Path=Error, Converter={StaticResource errorVisibilityConverter}}">
+                        <StackPanel Visibility="{Binding Path=ErrorMessage, Converter={StaticResource errorVisibilityConverter}}">
                             <StackPanel Orientation="Horizontal"
                                         HorizontalAlignment="Stretch">
                                 <Button x:Name="ErrorCloseButton"

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.2.1.0")]
+[assembly: AssemblyFileVersion("0.2.1.0")]


### PR DESCRIPTION
Sorry for the stupid bug. The error display was supposed to be available only when there is an error.